### PR TITLE
#4 removes references to texteverything.net from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # TextEverything
 Our project for HackNotts 2017.
 
-See our website: [http://texteverything.net](http://texteverything.net)
-
 ## The team
 - **Toby Jones [(monotron)](http://github.com/monotron)**
 - **Daniel Cordell [(DanielCordell)](http://github.com/DanielCordell)** 
@@ -16,6 +14,3 @@ An app that receives texts and executes whatever code you like.
 - Write plugins to make it do more stuff.
 
 We're working on a plugin repository, where users can upload plugins they've created and have other users of TextEverything download and review them.
-
-## The documentation
-You can find some documentation on [our website](http://texteverything.net/docs).


### PR DESCRIPTION
Removes the references from the README.md. Made sure to do a global search and didn't find any references elsewhere. 